### PR TITLE
Ticket 20: Resources page search bar bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npm install
 
 Next, create a db and import the latest dump from staging/production on S3 (extract file until you get a .sql file):
 ```
-bundle db:create
+bundle exec rake db:create
 psql bip_development < PostgreSQL.sql
 ```
 

--- a/app/helpers/resources_helper.rb
+++ b/app/helpers/resources_helper.rb
@@ -42,6 +42,10 @@ module ResourcesHelper
   end
 
   def resources_search_placeholder
-    params[:q] || 'Search resources by label/name'
+    'Search resources by label/name'
+  end
+  
+  def resources_search_initial_value
+    params[:q] || ''
   end
 end

--- a/app/views/resources/_filters.html.erb
+++ b/app/views/resources/_filters.html.erb
@@ -8,6 +8,7 @@
         type="text"
         name="q"
         placeholder="<%= resources_search_placeholder %>"
+        value="<%= resources_search_initial_value %>"
         class="filters__search-bar"
       ></input>
       <button class="filters__search-bar-submit" type="submit">


### PR DESCRIPTION
## [Ticket 20: Resources page search bar bug](https://unep-wcmc.codebasehq.com/projects/bip-website/tickets/20)

### Issue
The last query parameter is currently being used as a placeholder. So if you search for 'coral', when the page loads with your search results, 'coral' will be the placeholder of the input.

![image](https://user-images.githubusercontent.com/56026099/204560660-3f74db1c-cb0c-4738-85fc-097ec5e22bcf.png)

@lucacug asked me to fix this.

### Changes
New behaviour is that the last query is used to pre-populate the input, by passing this to the `<input>` element as its `value` attribute. The placeholder will now remain constant, add only appear when the field is cleared.

**Also**, I tweaked the README.md when I spotted an incorrect command in the set-up instructions.

### Testing
1. `git checkout fix/20-search-bar-bug`
2. Navigate to http://localhost:3000/resources
3. The search bar on the left should read 'Search resources by label/name', as placeholder text (see screenshot below)

![image](https://user-images.githubusercontent.com/56026099/204561879-cc12a375-2163-4790-9eb6-247dfe498404.png)
4. Enter a search term and run it. When the page reloads, the search bar should be pre-populated with the search term you just used.
5. Remove the text to check that the placeholder still reads 'Search resources by label/name' in the absence of any text content.
